### PR TITLE
Set scale and dedicated config to minimap

### DIFF
--- a/src/services/settings.js
+++ b/src/services/settings.js
@@ -10,7 +10,7 @@ const DEFAULT_SETTINGS = {
   credits: 'Source: TerraOpp',
   map: {
     minZoom: 6,
-    maxZoom: 17,
+    maxZoom: 20,
   },
   theme: {
     logo: '/images/logo.png',

--- a/src/views/Viewpoint/DetailViewpoint/SidebarTabsContent/InformationTab/Minimap/Minimap.js
+++ b/src/views/Viewpoint/DetailViewpoint/SidebarTabsContent/InformationTab/Minimap/Minimap.js
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
-import { CONTROLS_BOTTOM_RIGHT } from '@terralego/core/modules/Map/Map';
+import { CONTROLS_BOTTOM_RIGHT, CONTROLS_BOTTOM_LEFT, CONTROL_SCALE } from '@terralego/core/modules/Map/Map';
 import InteractiveMap, { CONTROL_BACKGROUND_STYLES } from '@terralego/core/modules/Map/InteractiveMap';
 import { useTranslation } from 'react-i18next';
 
@@ -44,6 +44,9 @@ const Minimap = ({
     controls: [{
       control: CONTROL_BACKGROUND_STYLES,
       position: CONTROLS_BOTTOM_RIGHT,
+    }, {
+      control: CONTROL_SCALE,
+      position: CONTROLS_BOTTOM_LEFT,
     }],
   }), [configMap, coordinates, layers, zoom]);
 

--- a/src/views/Viewpoint/DetailViewpoint/SidebarTabsContent/InformationTab/Minimap/Minimap.js
+++ b/src/views/Viewpoint/DetailViewpoint/SidebarTabsContent/InformationTab/Minimap/Minimap.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { CONTROLS_BOTTOM_RIGHT, CONTROLS_BOTTOM_LEFT, CONTROL_SCALE } from '@terralego/core/modules/Map/Map';
 import InteractiveMap, { CONTROL_BACKGROUND_STYLES } from '@terralego/core/modules/Map/InteractiveMap';
 import { useTranslation } from 'react-i18next';
+import merge from 'deepmerge';
 
 import { addCustomIcon } from '../../../../../../components/Visualizer/Visualizer';
 import MapErrorConfiguration from '../../../../../../components/MapErrorConfiguration';
@@ -11,10 +12,13 @@ import MapErrorConfiguration from '../../../../../../components/MapErrorConfigur
 import './Minimap.scss';
 
 const Minimap = ({
-  configMap: { zoom, ...configMap },
+  configMap,
+  configMiniMap,
   coordinates,
 }) => {
   const { t } = useTranslation();
+
+  const config = useMemo(() => merge.all([configMap, configMiniMap]), [configMap, configMiniMap]);
 
   const layers = [{
     id: 'viewpoint',
@@ -36,9 +40,8 @@ const Minimap = ({
   }];
 
   const props = useMemo(() => ({
-    ...configMap,
+    ...config,
     customStyle: { layers },
-    zoom: zoom + 1,
     center: coordinates,
     onMapInit: addCustomIcon,
     controls: [{
@@ -48,7 +51,7 @@ const Minimap = ({
       control: CONTROL_SCALE,
       position: CONTROLS_BOTTOM_LEFT,
     }],
-  }), [configMap, coordinates, layers, zoom]);
+  }), [config, coordinates, layers]);
 
 
   if (!configMap.accessToken || !configMap.backgroundStyle) {

--- a/src/views/Viewpoint/DetailViewpoint/SidebarTabsContent/InformationTab/Minimap/index.js
+++ b/src/views/Viewpoint/DetailViewpoint/SidebarTabsContent/InformationTab/Minimap/index.js
@@ -3,8 +3,9 @@ import { connectSettingsProvider } from '../../../../../../components/SettingsPr
 
 import Minimap from './Minimap';
 
-export default connectSettingsProvider(({ env: { map } }) => ({
+export default connectSettingsProvider(({ env: { map, minimap } }) => ({
   configMap: map,
+  configMiniMap: minimap,
 }))(connectViewpointProvider(({ viewpoint: { point: { coordinates } } }) => ({
   coordinates,
 }))(Minimap));


### PR DESCRIPTION
The settings could set a dedicated config to the minimap by following the same pattern of map like below:

```json
{
  "map": {
    "minZoom": 6,
    "maxZoom": 20,
  },
  "minimap": {
     "minZoom": 5, 
     "zoom": 15,
  }
}
``` 

The final config merges the `map` config overridden by the `minimap` config so the the result of the previous example will be :
```json
{
   "minZoom": 5, 
   "zoom": 15,
   "maxZoom": 20,
}
```